### PR TITLE
Fix Markdown header

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note that in IE, the element must have the focus for any of the following method
 
 ---
 
-####`getSelection()`
+### `getSelection()`
 
 Returns an object representing the user selection within the text input or textarea element.
 
@@ -62,7 +62,7 @@ Note that in IE the textarea or text input must have the focus before calling th
 
 ---
 
-####`setSelection(Number start[, Number end])`
+### `setSelection(Number start[, Number end])`
 
 Selects the text within the text input or textarea element between the specified start and end character indices.
 
@@ -76,7 +76,7 @@ To select the word "bar":
     
 ---
     
-####`collapseSelection(Boolean toStart)`
+### `collapseSelection(Boolean toStart)`
 
 Collapses the selection to an insertion point (caret) either at the start of the current selection if toStart is true or the end of the current selection otherwise.
 
@@ -90,7 +90,7 @@ To collapse the selection to the start:
 
 ---
 
-####`deleteText(Number start, Number end, Boolean moveSelection)`
+### `deleteText(Number start, Number end, Boolean moveSelection)`
 
 Deletes the text within the text input or textarea element between the specified start and end character indices and optionally places the caret at the position where the deleted text had been if moveSelection is true.
 
@@ -104,7 +104,7 @@ To delete the word "foo" from the example and place the caret where "foo" had be
 
 ---
 
-####`deleteSelectedText()`
+### `deleteSelectedText()`
 
 Deletes the currently selected text within the text input or textarea element and places the caret at the position where the deleted text had been.
 
@@ -116,7 +116,7 @@ Returns a reference to the original jQuery object for the element.
 
 ---
 
-####`extractSelectedText()`
+### `extractSelectedText()`
 
 Deletes the currently selected text within the text input or textarea element, places the caret at the position where the deleted text had been and returns the text that was deleted.
 
@@ -127,7 +127,7 @@ Deletes the currently selected text within the text input or textarea element, p
 
 ---
 
-####`insertText(String text, Number pos[, String selectionBehaviour])`
+### `insertText(String text, Number pos[, String selectionBehaviour])`
 
 Inserts the specified text at the specified character position within the text input or textarea element and optionally updates the selection depending on the value of selectionBehaviour. Possible values are:
 
@@ -147,7 +147,7 @@ To insert the word "baz" between "foo" and "bar" and place the caret immediately
 
 ---
 
-####`replaceSelectedText(String text[, String selectionBehaviour])`
+### `replaceSelectedText(String text[, String selectionBehaviour])`
 
 Replaces the currently selected text in the text input or textarea element with the specified text and optionally updates the selection depending on the value of selectionBehaviour. Possible values are: 
 
@@ -171,7 +171,7 @@ To do the same thing but select "baz" afterwards:
 
 ---
 
-####`surroundSelectedText(String textBefore, String textAfter[, String selectionBehaviour])`
+### `surroundSelectedText(String textBefore, String textAfter[, String selectionBehaviour])`
 
 Surrounds the currently selected text in the text input or textarea element with the specified pieces of text and optionally updates the selection depending on the value of `selectionBehaviour`. Possible values are:
 


### PR DESCRIPTION
In Markdown, it should add a space after `#`, to become a header

Also please add description:
><img width="836" alt="2017-03-28 00_29_37-zcyzcy88_rangyinputs_ rangy inputs" src="https://cloud.githubusercontent.com/assets/15178410/24367145/17821ca0-134e-11e7-9921-b95c4abc06bb.png">

